### PR TITLE
Ensure a browser runtime is installed for Playwright

### DIFF
--- a/template/tasks.py
+++ b/template/tasks.py
@@ -135,6 +135,8 @@ def test(ctx, name="", verbose=False, suite=None):
     Runs the test suite
     """
 
+    ctx.run("poetry run playwright install")  # ensure we have a playwright browser
+
     title_suffix = "S"
     args = ["poetry run pytest"]
     if verbose:


### PR DESCRIPTION
The template project uses playwrite for functional testing. Playright requires that a brower runtime is installed in order to run. To make the ergomics a little nicer for developer, the installation step has been added to the test runner task to it will happen automatically for people.

Longer term we might want to consider a `install` task or similar but this should keep things moving smoothly in the mean time