### PR TITLE
Use github markdown alert syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ you can create a new project with the following command:
 django-admin startproject --template path/to/django-template/template/ --extension py,env,sh,toml,yml <project_name>
 ```
 
-!!! warn
-    The name of your project _must_ be a valid Python package name - that means
-    underscores (`_`) not hyphens (`-`) for name separators please.
+> [!WARNING]
+> The name of your project _must_ be a valid Python package name - that means
+> underscores (`_`) not hyphens (`-`) for name separators please.
 
 Running the Django admin command will create a new project in the folder specified in
 with `<project_name>`.


### PR DESCRIPTION
Move the warning callout/alert to the Github flavoured markdown variant.

Before:
![image](https://github.com/ackama/django-template/assets/68017/3cd4dfa5-704c-4eb7-a7c8-7c9d01232a79)

After:
![image](https://github.com/ackama/django-template/assets/68017/e3663c54-f147-437e-899c-0784fa2dbc50)
