### PR TITLE
Use poetry export to ensure pinned requirements

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -3,11 +3,13 @@
 
 FROM python:3.12.0-slim-bullseye as packager
 ENV PYTHONUNBUFFERED=1
-RUN pip install -U pip && pip install poetry
+RUN pip install -U pip && pip install poetry poetry-plugin-export
 COPY README.md pyproject.toml poetry.lock /source/
 COPY src /source/src/
 WORKDIR /source/
-RUN rm -rf dist && poetry build
+
+# Uses export to get a pinned list of requirements
+RUN rm -rf dist && poetry export -o requirements.txt && poetry build
 
 
 # Building Stage
@@ -22,14 +24,21 @@ RUN apt-get update && apt-get install -y \
     libpq-dev \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --from=packager /source/dist/*.whl /
 RUN python -m venv /venv/
 
 # _activate_ the virtual environment
 ENV VIRTUAL_ENV=/venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip install -U pip && pip install *.whl
+RUN pip install -U pip
+
+# Install pinned dependencies
+COPY --from=packager /source/requirements.txt /
+RUN pip install -r requirements.txt
+
+# Install the application itself
+COPY --from=packager /source/dist/*.whl /
+RUN pip install --no-deps *.whl
 
 # Final Runtime
 # =============


### PR DESCRIPTION
The Docker file builds and then installs the application as a package. This works quite nicely to isolate the application entirely within a venv. It does however also mean that the Python dependencies are not fully pinned like they are for local development. The package that poetry builds uses the same constraints as those within the `pyproject.toml` _no_ those defined in the lock file. So there can be some discrepencies.

The Poetry export plugin can be used to export a `requirements.txt` that _does_ pin dependencies to specific versions. So here we are using it to create the `requirements.txt` which is then used in the second stage to install all the dependencies. The final install step of the wheel is done with the `--no-deps` flag preventing it from trying to install anyt dependencies itself as they should all already be installed.

Note: There are some plugins that aim to produce [frozen](https://github.com/cloud-custodian/poetry-plugin-freeze) or [locked](https://github.com/thesnapdragon/poetry-plugin-lockedbuild) wheels. The export plugin is an official plugin from the same people who produce Poetry. So I've opted for adding this extra step based on it being an officially supported plugin and therefore more likely to be kept up to date with changes in Poetry itself. We can re-evaluate this decision as needed.