### PR TITLE
Add ci configs/1

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,16 @@ This will ensure that the `django-admin` command is available in your shell. Fro
 you can create a new project with the following command:
 
 ```shell
-django-admin startproject --template path/to/django-template/template/ --extension py,env,sh,toml,yml <project_name>
+django-admin startproject --template path/to/django-template/template/ --extension py,env,sh,toml,yml --exclude nothing <project_name>
 ```
+
+> [!NOTE]
+> When initiating a Django project with a custom template, be aware that directories starting with
+> a dot (e.g., `.github` for GitHub Actions workflows) are not included by default. A workaround
+> from Django 4.0 onwards involves using the `--exclude` option with the `startproject` command.
+> Oddly, specifying `--exclude` with a non-existent directory can allow these dot-prefixed
+> directories to be copied. This trick can ensure that essential configurations like `.github` are
+> included in your project setup.
 
 > [!WARNING]
 > The name of your project _must_ be a valid Python package name - that means

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: Continuous Integration
+
+on: [push]
+
+jobs:
+  static-analysis-check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'poetry'
+
+    - name: Install dependencies
+      run: |
+        pip install invoke poetry
+        poetry install
+
+    - name: Run static analysis
+      run: poetry run invoke format

--- a/template/docs/how-tos/test_ci_workflows_locally.md
+++ b/template/docs/how-tos/test_ci_workflows_locally.md
@@ -1,0 +1,37 @@
+---
+tags:
+    - tasks
+---
+# Test CI Workflows Locally
+
+For developers familiar with GitHub Actions but looking to streamline their CI testing process locally, `act` offers a practical solution. Here’s how to leverage `act` for local CI workflow testing:
+
+## Requirements
+- `act` installed on your machine. For installation, see the [`act` User Guide][act-user-guide].
+
+## Using `act` for Local Workflow Testing
+
+1. **Ensure `act` is Installed**: Confirm `act` is set up on your system. If you’re unsure, run `act -h` in your terminal to check for its presence.
+
+2. **Prepare Your Project**: Navigate to your project’s root directory in the terminal, ensuring you’re in the same location as your `.github` workflow directory.
+
+3. **Execute a Workflow with `act`**:
+    - To simulate a `push` event, use:
+
+      ```shell
+      act push --container-architecture linux/amd64
+      ```
+
+    - Substitute `push` with any event relevant to your workflows, such as `pull_request`, if needed.
+    - Adjust `--container-architecture` as per your project's or local setup's needs (e.g., `linux/arm64` for ARM-based systems).
+
+4. **Analyze the Execution Output**: Examine the terminal output for insights into the workflow execution, and adjust your workflow files or code based on the feedback provided.
+
+### Tips for Efficient Use
+
+- **Iterate Quickly**: Use `act` to rapidly test changes to your workflows without pushing to GitHub, saving time and avoiding unnecessary commits.
+- **Customization**: Tailor the `act` command with additional flags as needed for your specific testing scenario, such as specifying a different GitHub event or workflow file.
+
+By integrating `act` into your local development workflow, you gain a powerful tool for preemptively identifying and fixing issues in your CI process, enhancing overall efficiency and reliability.
+
+[act-user-guide]: https://github.com/nektos/act#readme


### PR DESCRIPTION
This change:
- Fixes a few typos
- Adds a basic CI configuration to run `format` task on the subproject
- Adds a documentation about how to use 'act' to run github workflows locally.
- Updates the README file with how to include github workflows when starting  a new project.

issue: https://github.com/ackama/django-template/issues/12