### PR TITLE
Add ci configs/2

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -25,4 +25,25 @@ jobs:
       run: |
         poetry run invoke lint
         poetry run invoke format --check
+
+  type-checking:
+    name: Type Checking
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'poetry'
+
+    - name: Install dependencies
+      run: |
+        pip install invoke poetry
+        poetry install
+
+    - name: Run type-checking
+      run: poetry run invoke typing
   

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ name: Continuous Integration
 on: [push]
 
 jobs:
-  static-analysis-check:
+  static-analysis-checks:
+    name: Static analysis Checks
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
@@ -20,5 +21,8 @@ jobs:
         pip install invoke poetry
         poetry install
 
-    - name: Run static analysis
-      run: poetry run invoke format
+    - name: Run linting and formatting
+      run: |
+        poetry run invoke lint
+        poetry run invoke format --check
+  

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -46,4 +46,31 @@ jobs:
 
     - name: Run type-checking
       run: poetry run invoke typing
-  
+
+  documentation-building:
+    name: Documentation Building
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+        cache: 'poetry'
+
+    - name: Install dependencies
+      run: |
+        pip install invoke poetry
+        poetry install
+
+    - name: Build the documentation
+      # When running the ci locally using act, MkDocs build fails at "make html" with
+      # `ValueError: ZoneInfo keys may not be absolute paths, got: /UTC.`
+      # It seems to be a timezone related issue that arises from the interaction of the Python
+      # packages babel & zoneinfo.
+      # setting `TZ=UTC` is a work around here to bypass that error.
+      # NOTE: it runs fine when pushing to Github, but unfortunately not in act.
+      # link to issue on act repository: https://github.com/nektos/act/issues/1853
+      run: TZ=UTC poetry run invoke build-docs

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -24,13 +24,17 @@ def help(ctx):
 
 
 @invoke.task
-def format(ctx):
+def format(ctx, check:bool = False) -> None:
     """
-    Apply automatic code formating tools
+    Apply automatic code formatting tools
+
+    By default, this modifies files to match coding style guidelines.
+    When `check` is True, it performs a dry-run to identify non-compliant
+    files without applying changes.
     """
     _title("Applying code formatters ")
-    ctx.run("poetry run black src")
-    ctx.run("poetry run isort src")
+    ctx.run(f"poetry run black src{' --check' if check else ''}")
+    ctx.run(f"poetry run isort src{' --check' if check else ''}")
 
 
 @invoke.task


### PR DESCRIPTION
This change adds the following CI configs:
- Linting
- Type checking
- Doc building

issue: https://github.com/ackama/django-template/issues/12