### PR TITLE
Ignore .DS_Store files across the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ data/
 dist/
 htmlcov/
 site/
+.DS_Store

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -12,3 +12,4 @@ data/
 dist/
 htmlcov/
 site/
+.DS_Store


### PR DESCRIPTION
.DS_Store files are created by macOS to store custom folder
attributes, like icon positions and background images. While
they're useful locally on a Mac, they're unnecessary in
version control and can lead to clutter. Ignoring these files
across the project enhances cross-platform compatibility and
keeps the repository clean.