### PR TITLE
Setup Python action upgraded to version 5

### DIFF
--- a/.github/workflows/startproject.yml
+++ b/.github/workflows/startproject.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Version 4 of the `setup-python` action uses an end of life node version. Upgrading here to version 5 to resolve the warning that generates.