### PR TITLE
Add a basic ci job to run Docker image builder

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -176,6 +176,23 @@ jobs:
     needs: [static-analysis-checks, type-checking, run-system-tests, run-functional-tests]
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: dev
+          POSTGRES_PASSWORD: dev_password
+          POSTGRES_DB: dev
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+            # Allows us to use the same env config used locally by mapping to port to
+            # the test runner container.
+            - 5432:5432
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -188,5 +205,14 @@ jobs:
     - name: Install dependencies
       run: pip install invoke
 
-    - name: Build Docker Image
+    - name: Setup environment variables
+      run: |
+        cp example.env .env
+        echo 'DATABASE_URL=postgres://dev:dev_password@postgres:5432/dev'  >> .env
+
+    - name: Build service Docker Image
       run: invoke build-image
+
+    - name: Run service Docker image
+      run: |
+        invoke run-image --options '--network {% verbatim %}${{ job.container.network }}{% endverbatim %} --env-file .env' --command check

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -170,3 +170,23 @@ jobs:
 
     - name: Run the functional test suite
       run: poetry run invoke test --suite=functional
+
+  build-docker-image:
+    name: Build Docker Image
+    needs: [static-analysis-checks, type-checking, run-system-tests, run-functional-tests]
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      run: pip install invoke
+
+    - name: Build Docker Image
+      run: invoke build-image

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -208,6 +208,32 @@ def build_image(ctx, tag=None, pty=True):
 
 
 @invoke.task
+def run_image(
+    ctx, tag: str | None = None, options: str | None = None, command: str | None = None
+):
+    """
+    Run the service Docker image
+
+    Alternatively execute input commands in the container.
+    """
+    _title("Running Docker image 🐳")
+
+    if tag is None:
+        data = _build_data(ctx)
+        tag = data.tag
+
+    if options is None:
+        options = "--env-file .env"
+
+    args = [f"docker run --rm {options} {PACKAGE}:{tag}"]
+
+    if command:
+        args.append(command)
+
+    ctx.run(" ".join(args), echo=True)
+
+
+@invoke.task
 def build_docs(ctx):
     """
     Build the {{ project_name }} documentation
@@ -239,6 +265,7 @@ def install(ctx, skip_install_playwright: bool = False):
     if not skip_install_playwright:
         _title("Installing Playwright Dependencies")
         ctx.run("poetry run playwright install --with-deps")
+
 
 ###########
 # HELPERS #


### PR DESCRIPTION
This change adds the last piece required in https://github.com/ackama/django-template/issues/12
Adds:
- An invoke task to run the service Docker image
- A CI job to build and test the docker image