### PR TITLE
Task tweaks

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -66,8 +66,8 @@ jobs:
     - name: Build the documentation
       # When running the ci locally using act, MkDocs build fails at "make html" with
       # `ValueError: ZoneInfo keys may not be absolute paths, got: /UTC.`
-      # It seems to be a timezone related issue that arises from the interaction of the Python
-      # packages babel & zoneinfo.
+      # It seems to be a timezone related issue that arises from the interaction of the
+      # Python packages babel & zoneinfo.
       # setting `TZ=UTC` is a work around here to bypass that error.
       # NOTE: it runs fine when pushing to Github, but unfortunately not in act.
       # link to issue on act repository: https://github.com/nektos/act/issues/1853
@@ -162,9 +162,10 @@ jobs:
         invoke install
         cp example.env .env
 
-      # Since there are separate jobs for running system and functional tests independently,
-      # and we use different ports to access the database, the following configuration sets up
-      # the environment variable to point to the correct database URL.
+      # Since there are separate jobs for running system and functional tests
+      # independently, and we use different ports to access the database, the following
+      # configuration sets up the environment variable to point to the correct database
+      # URL.
     - name: Set DATABASE_URL for functional tests
       run: echo "DATABASE_URL=postgres://dev:dev_password@localhost:5433/dev" >> $GITHUB_ENV
 
@@ -177,8 +178,9 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      postgres:
+      db:
         image: postgres:16
+
         env:
           POSTGRES_USER: dev
           POSTGRES_PASSWORD: dev_password
@@ -189,8 +191,6 @@ jobs:
           --health-timeout 5s
           --health-retries 5
         ports:
-            # Allows us to use the same env config used locally by mapping to port to
-            # the test runner container.
             - 5432:5432
 
     steps:
@@ -208,11 +208,12 @@ jobs:
     - name: Setup environment variables
       run: |
         cp example.env .env
-        echo 'DATABASE_URL=postgres://dev:dev_password@postgres:5432/dev'  >> .env
 
     - name: Build service Docker Image
       run: invoke build-image
 
     - name: Run service Docker image
+      # Since we are running the app in docker we need to ensure it attaches to the same
+      # virtual network.
       run: |
-        invoke run-image --options '--network {% verbatim %}${{ job.container.network }}{% endverbatim %} --env-file .env' --command check
+        invoke run-image --network {% verbatim %}${{ job.container.network }}{% endverbatim %} --command check

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -9,6 +9,9 @@ import invoke
 
 PACKAGE = "{{ project_name }}"
 
+###################
+# GETTING STARTED #
+###################
 
 @invoke.task
 def help(ctx):
@@ -16,6 +19,23 @@ def help(ctx):
     Displays help text
     """
     ctx.run("inv -l", pty=True)
+
+@invoke.task()
+def install(ctx, skip_install_playwright: bool = False):
+    """
+    Install system dependencies necessary for the {{ project_name }} project.
+
+    This task optionally skips the installation of Playwright dependencies,
+    which is useful for CI pipelines where Playwright is not needed,
+    thereby improving the build performance.
+    """
+    _title("Installing Dependencies")
+    ctx.run("poetry install")
+
+    if not skip_install_playwright:
+        _title("Installing Playwright Dependencies")
+        ctx.run("poetry run playwright install --with-deps")
+
 
 
 #####################
@@ -81,10 +101,9 @@ def lint(ctx):
     stdout_captured = []
 
     # Need to collect the `stdout` during the command run in order to check
-    #  for specific error messages in the output
-    # UnexpectedExit doesn't hold the stdout, and could capture stdout to a
-    #  stream, but then if stdout and stderr both output they will not interpolate
-    #  correctly
+    # for specific error messages in the output UnexpectedExit doesn't hold the stdout,
+    # and could capture stdout to a stream, but then if stdout and stderr both output
+    # they will not interpolate correctly
     class StreamInterceptor(invoke.watchers.StreamWatcher):
         def submit(self, stream):
             stdout_captured.append(stream)
@@ -101,8 +120,8 @@ def lint(ctx):
                     " `inv format` to autoformat the code"
                 )
                 break
-        # By catching and raising the UnexpectedExit exception, the 'terminate on
-        #  error' behaviour of invoke is preserved
+        # By catching and raising the UnexpectedExit exception, the 'terminate on error'
+        # behaviour of invoke is preserved
         raise
 
 
@@ -206,6 +225,19 @@ def build_image(ctx, tag=None, pty=True):
         echo=True,
     )
 
+@invoke.task
+def build_docs(ctx):
+    """
+    Build the {{ project_name }} documentation
+    """
+    _title("Building documentation")
+    ctx.run("poetry run mkdocs build --strict")
+
+
+###########
+# RUNNING #
+###########
+
 
 @invoke.task
 def run_image(
@@ -233,13 +265,7 @@ def run_image(
     ctx.run(" ".join(args), echo=True, pty=True)
 
 
-@invoke.task
-def build_docs(ctx):
-    """
-    Build the {{ project_name }} documentation
-    """
-    _title("Building documentation")
-    ctx.run("poetry run mkdocs build --strict")
+
 
 
 @invoke.task
@@ -248,24 +274,6 @@ def run_docs(ctx):
     Run the {{ project_name }} documentation locally
     """
     ctx.run("poetry run mkdocs serve")
-
-
-@invoke.task
-def install(ctx, skip_install_playwright: bool = False):
-    """
-    Install system dependencies necessary for the {{ project_name }} project.
-
-    This task optionally skips the installation of Playwright dependencies,
-    which is useful for CI pipelines where Playwright is not needed,
-    thereby improving the build performance.
-    """
-    _title("Installing Dependencies")
-    ctx.run("poetry install")
-
-    if not skip_install_playwright:
-        _title("Installing Playwright Dependencies")
-        ctx.run("poetry run playwright install --with-deps")
-
 
 ###########
 # HELPERS #

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -241,7 +241,12 @@ def build_docs(ctx):
 
 @invoke.task
 def run_image(
-    ctx, tag: str | None = None, options: str | None = None, command: str | None = None
+    ctx,
+    tag: str | None = None,
+    network: str | None = None,
+    env_file: str | None = None,
+    database_url: str | None = None,
+    command: str | None = None,
 ):
     """
     Run the service Docker image
@@ -250,22 +255,26 @@ def run_image(
     """
     _title("Running Docker image 🐳")
 
-    if tag is None:
-        data = _build_data(ctx)
-        tag = data.tag
+    tag = tag or _build_data(ctx).tag
+    network = network or f"{PACKAGE}_default"
+    env_file = env_file or ".env"
+    database_url = database_url or "postgres://dev:dev_password@db:5432/dev"
 
-    if options is None:
-        options = "--env-file .env"
-
-    args = [f"docker run --rm -p 8000:8000 {options} {PACKAGE}:{tag}"]
+    args = [
+        "docker run",
+        "--rm",
+        "-it",
+        "-p 8000:8000",
+        f"--network {network}",
+        f"-e DATABASE_URL={database_url}",
+        f"--env-file {env_file}",
+        f"{PACKAGE}:{tag}"
+    ]
 
     if command:
         args.append(command)
 
     ctx.run(" ".join(args), echo=True, pty=True)
-
-
-
 
 
 @invoke.task

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -225,12 +225,12 @@ def run_image(
     if options is None:
         options = "--env-file .env"
 
-    args = [f"docker run --rm {options} {PACKAGE}:{tag}"]
+    args = [f"docker run --rm -p 8000:8000 {options} {PACKAGE}:{tag}"]
 
     if command:
         args.append(command)
 
-    ctx.run(" ".join(args), echo=True)
+    ctx.run(" ".join(args), echo=True, pty=True)
 
 
 @invoke.task

--- a/template/tasks.py
+++ b/template/tasks.py
@@ -308,7 +308,7 @@ def _build_data(ctx) -> BuildData:
 
     commit_hash = ctx.run("git rev-parse --short=12 HEAD", hide="stdout").stdout.strip()
     commit_time = ctx.run("git show -s --format=%ct", hide="stdout").stdout.strip()
-    commit_count = ctx.run("git rev-list --count HEAD").stdout.strip()
+    commit_count = ctx.run("git rev-list --count HEAD", hide="stdout").stdout.strip()
     return BuildData(
         branch=branch,
         commit_hash=commit_hash,


### PR DESCRIPTION
A bunch of minor tweaks to the invoke tasks of created projects:

- Adds port mapping and a PTY to the `run-container` task
- Makes sure that stdout is hidden during release number calculation
- Adds some new sections and moved some tasks around to group like with like
- Refactors the image-run task to be a little more flexible.
