### PR TITLE
Use full checkout for docker image building

### DIFF
--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -214,6 +214,10 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        # The tag applied to the Docker image we build is based on the number of commits
+        # on the current branch. This is only accurate when you have a _full_ checkout.
+        fetch-depth: 0
 
     - name: Install management tools
       run: pipx install invoke


### PR DESCRIPTION
We build the docker tag in part from the number of commits on the current branch. This provides a number value that can only increaase over time. A useful automated "release" or "version" number. However, it relies on `git rev-list` which in turn requires _all_ the commits to be available in order to get an accurate count. The default for github actions is a shallow fetch. So here we change it to fetch the whole shebang whem building the Docker image.