### PR TITLE
Cyclomatic complexity checking enabled

### DIFF
--- a/template/setup.cfg
+++ b/template/setup.cfg
@@ -7,3 +7,4 @@ exclude =
     data
 per-file-ignores =
     src/tests/*: S101
+max-complexity = 15


### PR DESCRIPTION
Adds config for McCabe cyclomatic complexity checking. McCabe described a series of bands of complexity as follows:

* `1 - 10`: Simple procedure, little risk
* `11 - 20`: More complex, moderate risk
* `21 - 50`: Complex, high risk
* `> 50`: Untestable code, very high risk

Here I have leaned toward prompting at a medium, moderate level of complexity with a limit of `15`. This is a little higher than many examples seen in the wild. Not because I want to encourage large, or complex functions - but because I don't want to make it overly judgemental when you do. There are, and always will be good reasons to have complex functions. So what I am trying to do here is prompt people when they go too far. Not punish them for a minor infraction.

As with all flake8 checks, this can be turned off on a case by case basis in the code with a comment. So we can still exceed this number if it is deemed necessary and you can get a team mate to sign off on the PR.