### PR TITLE
Binds postgres to localhost

### DIFF
--- a/template/docker-compose.yml
+++ b/template/docker-compose.yml
@@ -1,10 +1,8 @@
-version: "3"
-
 services:
   db:
     image: postgres:16
     ports:
-      - 5432:5432
+      - 127.0.0.1:5432:5432
     environment:
       - POSTGRES_USER=dev
       - POSTGRES_PASSWORD=dev_password


### PR DESCRIPTION
Ensures that the port mapping for Postgres in the docker compose file is bound 127.0.0.1:5432 so it is not available over the local network.

Access from another machine should not be needed for a local development environment and presents an additional security risk. These backing services are not as rigorously locked down as they would be in a production environment.

I also removed the version in the docker-compose file as is no longer needed by newer versions of docker compose, and generating a warning each time it is used.