### PR TITLE
ci: update `actions/checkout` action to version that uses Node v24

### DIFF
--- a/.github/workflows/startproject.yml
+++ b/.github/workflows/startproject.yml
@@ -32,7 +32,7 @@ jobs:
             - 5432:5432
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
 

--- a/template/.github/workflows/ci.yml
+++ b/template/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -101,7 +101,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -149,7 +149,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
@@ -209,7 +209,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         # The tag applied to the Docker image we build is based on the number of commits
         # on the current branch. This is only accurate when you have a _full_ checkout.


### PR DESCRIPTION
Action runners using Node v20 are deprecated, and will be [removed](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). 

This PR updates us to using `actions/checkout@v6` which supports Node v24. Release notes can be found [here](https://github.com/actions/checkout/releases/tag/v6.0.0)