### PR TITLE
Can create a project with vite bundled typescript support

### DIFF
--- a/copier.yml
+++ b/copier.yml
@@ -20,3 +20,14 @@ use_feature_toggles:
     type: bool
     help: Do you want support for feature toggles?
     default: true
+
+ts_integration:
+    type: bool
+    help: Do you want to build static assets with TypeScript?
+    default: false
+
+use_htmx:
+    type: bool
+    help: Do you want to use htmx for dynamic frontend interactions?
+    when: "{{ ts_integration }}"
+    default: false

--- a/template/.gitignore.jinja
+++ b/template/.gitignore.jinja
@@ -1,6 +1,7 @@
 __pycache__
 .coverage
 .dmypy.json
+.DS_Store
 .env
 .mypy_cache
 .pytest_cache
@@ -11,5 +12,6 @@ coverage.xml
 data/
 dist/
 htmlcov/
+node_modules/
 site/
-.DS_Store
+{% if ts_integration %}src/{{ project_module }}/static/assets/*{% endif %}

--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -1,11 +1,25 @@
 # Packaging Stage
 # ===============
 
+{% if ts_integration %}
+FROM node:24.15 AS assets
+COPY vite.config.js /source/
+COPY tsconfig.json /source/
+COPY package.json /source/
+COPY package-lock.json /source
+WORKDIR /source
+RUN npm install
+
+COPY src/assets /source/src/assets/
+RUN npm run build 
+{% endif %}
+
 FROM python:3.12.8-slim-bookworm AS packager
 ENV PYTHONUNBUFFERED=1
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 COPY README.md pyproject.toml uv.lock /source/
 COPY src /source/src/
+{% if ts_integration %}COPY --from=assets /source/src/{{ project_module }}/static/assets/ /source/src/{{ project_module }}/static/assets/{% endif %}
 WORKDIR /source/
 
 # Uses export to get a pinned list of requirements

--- a/template/docs/how-tos/{% if ts_integration %}use-typescript-assets.md{% endif %}.jinja
+++ b/template/docs/how-tos/{% if ts_integration %}use-typescript-assets.md{% endif %}.jinja
@@ -1,0 +1,63 @@
+---
+tags:
+  - Frontend
+  - Assets
+  - TypeScript
+  - How-To
+---
+# Build and Use TypeScript Assets in Templates
+
+This guide shows how to update frontend TypeScript assets and load them in
+Django templates.
+
+## 1. Update Asset Source
+
+Edit the TypeScript source in `src/assets/`, usually:
+
+- `src/assets/main.ts`
+
+## 2. Build Assets
+
+Run:
+
+```shell
+inv build-assets
+```
+
+If dependencies are already installed and unchanged, you can skip reinstalling
+npm packages:
+
+```shell
+inv build-assets --no-install-deps
+```
+
+After build, compiled files are written to:
+
+- `src/{{ project_module }}/static/assets/`
+
+## 3. Load the Built Asset in a Django Template
+
+Use Django's `static` template tag.
+{% raw %}
+```django
+{% load static %}
+<script src="{% static 'assets/main.js' %}"></script>
+```
+{% endraw %}
+Important:
+
+- Load the `static` tag before using it.
+- Reference the asset path as `assets/<filename>`.
+- Do not hardcode `/static/assets/...` URLs.
+
+## 4. Verify
+
+1. Confirm output exists in `src/{{ project_module }}/static/assets/`.
+2. Reload your page and check that the script request succeeds.
+3. If changes do not appear, perform a hard refresh to bypass browser cache.
+
+## Docker Note
+
+When you build the Docker image, frontend assets are rebuilt as part of the
+Dockerfile build process. You do not need a separate runtime step in the
+container to compile assets.

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -18,6 +18,7 @@ dependencies = [
     "sentry-sdk>=2.55.0,<3",
     "httptools>=0.7.1,<1",
     {% if use_feature_toggles %}"django-waffle>=5.0.0,<6",{% endif %}
+    {% if use_htmx %}"django-htmx>=1.27.0,<2",{% endif %}
 ]
 
 [project.scripts]

--- a/template/src/{% if ts_integration %}assets{% endif %}/main.ts.jinja
+++ b/template/src/{% if ts_integration %}assets{% endif %}/main.ts.jinja
@@ -1,0 +1,1 @@
+{% if use_htmx %}import 'htmx.org';{% endif %}

--- a/template/tasks.py.jinja
+++ b/template/tasks.py.jinja
@@ -202,8 +202,17 @@ def build_image(ctx, tag=None, pty=True):
         pty=pty,
         echo=True,
     )
-
-
+{% if ts_integration %}
+@invoke.task
+def build_assets(ctx, install_deps=True):
+    """
+    Build the {{ project_module }} static assets
+    """
+    _title("Building static assets")
+    if install_deps:
+        ctx.run("npm install")
+    ctx.run("npm run build")
+{% endif %}
 @invoke.task
 def build_docs(ctx):
     """

--- a/template/{% if ts_integration %}package.json{% endif %}.jinja
+++ b/template/{% if ts_integration %}package.json{% endif %}.jinja
@@ -1,0 +1,16 @@
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "format": "prettier src/assets --write",
+    "lint": "prettier src/assets --check"
+  },
+  "dependencies":{
+    {% if use_htmx %}"htmx.org": "^2.0.8"{% endif %}
+  },
+  "devDependencies": {
+    "prettier": "^3.7.3",
+    "vite": "^6.0.0"
+  }
+}

--- a/template/{% if ts_integration %}tsconfig.json{% endif %}.jinja
+++ b/template/{% if ts_integration %}tsconfig.json{% endif %}.jinja
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES6",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["vite/client"],
+    "noEmit": true,
+    "noEmitOnError": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}

--- a/template/{% if ts_integration %}vite.config.js{% endif %}.jinja
+++ b/template/{% if ts_integration %}vite.config.js{% endif %}.jinja
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+
+export default defineConfig({
+    root: resolve('./src/'),
+    base: '/static/assets/',
+    build: {
+        outDir: resolve('./src/{{ project_module }}/static/assets/'),
+        rollupOptions: {
+            input: {
+                main: resolve('./src/assets/main.ts')
+            },
+            output: {
+                entryFileNames: `[name].js`,
+                chunkFileNames: `[name].js`,
+                assetFileNames: `[name][extname]`
+            }
+        },
+    },
+});


### PR DESCRIPTION
Adds optional static assets build pipeline using vite as a bundler.

If Typescript support is requests, the optional use of HTMX can also be turned on which will include htmx in the standard asset bundle as well as django-htmx for backend support.

Note: I am far from a JS/TS expert. So the configuration included here is very much my amateur attempt at getting the right balance. So I am very much open to feedback on config. 