### PR TITLE
feat: add `djangofmt` as a tool for for formatting django templates

### DIFF
--- a/docs/decisions/0009-djangofmt.md
+++ b/docs/decisions/0009-djangofmt.md
@@ -1,0 +1,40 @@
+# 0009 Architectural Decision Record Template
+
+- Date: 2026-04-23
+- Author(s): [Laura Corkin][nzlaura]
+- Status: `Active`
+
+## Decision
+
+Adopting [djangofmt][djangofmt] as a linting tool for Django templates
+
+## Context
+
+Through development on a number of codebases, one of the challenges that comes up for readability and maintenance
+when working with django templates has been inconsistent formatting our django templates. We don't currently have
+any tools that we're using to format or lint our django templates. In the past, finding a library to format our 
+Django templates has been challenging, because often tools used for formatting `.html` files have a negative impact
+on template tags, thus causing issues with functionality. 
+
+We found a tool [djangofmt][djangofmt]- which consistently lints templates without impacting functionality of the 
+template tags we use in Django templates. It has a small number of configuration options that you can use to suit 
+your preferences for how the tool works.
+
+Another package considered was [djLint][djLint] as it is a well established Django template formatting library. 
+There were a number of drawbacks with using this package, for example it had some less than ideal formatting for 
+attributes. 
+ 
+The library also has a large number of configuration options, which can at times make it challenging to decide on a
+set of sensible defaults for how we'd like to use it within our projects. 
+
+## Implications
+
+This adds a tool which has a slightly different configuration to our usual python code, using two spaces for indenting. 
+Two space indenting matches the tooling we use for frontend code formatting, and can improve readability in django templates.
+
+In addition, we've chosen to retain self-closing void tags, which again is in line with frontend tooling like prettier.
+
+<!-- Links -->
+[nzlaura]: mailto:laura.corkin@ackama.com
+[djangofmt]: https://github.com/UnknownPlatypus/djangofmt
+[djLint]: https://github.com/djlint/djLint

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -26,6 +26,7 @@ manage = "{{ project_module }}.manage:main"
 [dependency-groups]
 dev = [
     "django-stubs>=6.0.0,<7",
+    "djangofmt>=0.2.7",
     "factory-boy>=3.3.0,<4",
     "invoke>=2.2.1,<3",
     "ipython>=9.11.0,<10",
@@ -89,6 +90,12 @@ filterwarnings = """
 
 [tool.coverage.run]
 omit = ["**/migrations/*"]
+
+[tool.djangofmt]
+line-length = 80
+indent-width = 2
+profile = "django"
+html-void-self-closing = "always"
 
 
 [tool.ruff.lint]

--- a/template/tasks.py.jinja
+++ b/template/tasks.py.jinja
@@ -56,7 +56,10 @@ def format(ctx, check: bool = False) -> None:  # noqa: A001
     suffix = " (check only)" if check else ""
     _title(f"Applying code formatters{suffix}")
     ctx.run(f"uv run ruff format src{' --check' if check else ''}")
-    ctx.run(f"uv run ruff check --select I{' --fix' if not check else ''} src")
+    ctx.run(
+        'uv run djangofmt . && git diff --exit-code -- "*.html" || '
+        '(echo "HTML templates are not formatted. Run \'djangofmt\' to fix." && exit 1)'
+    )
 
 
 @invoke.task
@@ -100,6 +103,7 @@ def lint(ctx, fix=False):
     Check linting in the src folder
     """
     _title("Linting code")
+    ctx.run(f"uv run ruff check{' --fix ' if fix else ''} src")
     ctx.run(f"uv run ruff check{' --fix ' if fix else ''} src")
 
 

--- a/template/tasks.py.jinja
+++ b/template/tasks.py.jinja
@@ -57,10 +57,13 @@ def format(ctx, check: bool = False) -> None:  # noqa: A001
     _title(f"Applying code formatters{suffix}")
     ctx.run(f"uv run ruff format src{' --check' if check else ''}")
     ctx.run(f"uv run ruff check --select I{' --fix' if not check else ''} src")
-    ctx.run(
-        'uv run djangofmt . && git diff --exit-code -- "*.html" || '
-        '(echo "HTML templates are not formatted. Run \'djangofmt\' to fix." && exit 1)'
-    )
+    if check:
+        ctx.run(
+            'uv run djangofmt . && git diff --exit-code -- "*.html" || '
+            '(echo "HTML templates are not formatted. Run \'djangofmt\' to fix."    && exit 1)'
+        )
+    else:
+        ctx.run("uv run djangofmt .")
 
 
 @invoke.task
@@ -104,7 +107,6 @@ def lint(ctx, fix=False):
     Check linting in the src folder
     """
     _title("Linting code")
-    ctx.run(f"uv run ruff check{' --fix ' if fix else ''} src")
     ctx.run(f"uv run ruff check{' --fix ' if fix else ''} src")
 
 

--- a/template/tasks.py.jinja
+++ b/template/tasks.py.jinja
@@ -56,6 +56,7 @@ def format(ctx, check: bool = False) -> None:  # noqa: A001
     suffix = " (check only)" if check else ""
     _title(f"Applying code formatters{suffix}")
     ctx.run(f"uv run ruff format src{' --check' if check else ''}")
+    ctx.run(f"uv run ruff check --select I{' --fix' if not check else ''} src")
     ctx.run(
         'uv run djangofmt . && git diff --exit-code -- "*.html" || '
         '(echo "HTML templates are not formatted. Run \'djangofmt\' to fix." && exit 1)'


### PR DESCRIPTION
Adds `djangofmt` as tool for formatting Django templates. 

Closes: https://github.com/ackama/django-template/issues/101