### PR TITLE
Corrects docker Python version

### DIFF
--- a/template/Dockerfile.jinja
+++ b/template/Dockerfile.jinja
@@ -13,7 +13,7 @@ RUN npm run build
 # Packaging Stage
 # ===============
 
-FROM python:3.12.8-slim-bookworm AS packager
+FROM python:3.14.5-slim-trixie AS packager
 ENV PYTHONUNBUFFERED=1
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 COPY README.md pyproject.toml uv.lock /source/
@@ -30,7 +30,7 @@ RUN rm -rf dist \
 # Building Stage
 # ==============
 
-FROM python:3.12.8-slim-bookworm AS builder
+FROM python:3.14.5-slim-trixie AS builder
 ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && apt-get install -y \
@@ -58,7 +58,7 @@ RUN pip install --no-deps *.whl
 # Final Runtime
 # =============
 
-FROM python:3.12.8-slim-bookworm AS runtime
+FROM python:3.14.5-slim-trixie AS runtime
 ENV PYTHONUNBUFFERED=1
 
 ARG GIT_COMMIT_HASH

--- a/template/tasks.py.jinja
+++ b/template/tasks.py.jinja
@@ -8,6 +8,7 @@ import invoke
 #############
 
 PACKAGE = "{{ project_module }}"
+ROOT_DIR = pathlib.Path(__file__).parent
 
 ###################
 # GETTING STARTED #
@@ -61,7 +62,7 @@ def typing(ctx):
     _title("Type checking")
     # PYTHONPATH must include the `src` folder for django-stubs to find the settings
     # module
-    src_path = str((pathlib.Path() / "src").absolute())
+    src_path = str((ROOT_DIR / "src").absolute())
     with ctx.prefix(f"export PYTHONPATH=${{PYTHONPATH}}:{src_path}"):
         try:
             ctx.run(f"uv run dmypy run -- src/{PACKAGE}")
@@ -258,7 +259,7 @@ def run_image(
     _title("Running Docker image 🐳")
 
     tag = tag or _build_data(ctx).tag
-    network = network or f"{PACKAGE}_default"
+    network = network or f"{ROOT_DIR.name}_default"
     env_file = env_file or ".env"
     database_url = database_url or "postgres://dev:dev_password@db:5432/dev"
 


### PR DESCRIPTION
The project was updated to Pythn 3.14 but the change missed the Dockfile itself. This change ensure that the Docker image is also running Python 3.14 as well as switching to Debian Trixe.

The Docker compose default network name is based on the directory containing the compose file. Previously we assumed that the directory and the package name would match, this is not always true. So the invoke take that runs the containerised version of the app now uses the folder name too.